### PR TITLE
fix compile error

### DIFF
--- a/nori/main.cpp
+++ b/nori/main.cpp
@@ -78,8 +78,14 @@ void sortByName(std::vector<std::string>& names)
 
 std::string getAuthorName()
 {
-    return somera::StringHelper::replace(
-        somera::SubprocessHelper::call("git config user.name"), "\n", "");
+    std::error_code err;
+    std::string result;
+    std::tie(result, err) = somera::SubprocessHelper::call("git config user.name");
+
+    if (err) {
+        return "";
+    }
+    return somera::StringHelper::replace(result, "\n", "");
 }
 
 template <class Container, typename Func>


### PR DESCRIPTION
This commit fixes the following compile error.

```
main.cpp:82:9: error: no viable conversion from 'std::tuple<std::string, std::error_code>' to 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char>
      >')
        somera::SubprocessHelper::call("git config user.name"), "\n", "");
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
